### PR TITLE
add p2p-webrtc-direct pattern

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -13,16 +13,11 @@ var DNS4 = Base(madns.P_DNS4)
 // Define a dns6 format multiaddr
 var DNS6 = Base(madns.P_DNS6)
 
-var _DNS = Or(
+// Define a dnsaddr, dns4 or dns6 format multiaddr
+var DNS = Or(
 	Base(madns.P_DNSADDR),
 	DNS4,
 	DNS6,
-)
-
-// Define a dns4 or dns6 format multiaddr
-var DNS = Or(
-	And(_DNS, Base(ma.P_TCP)),
-	_DNS,
 )
 
 // Define IP as either ipv4 or ipv6

--- a/patterns.go
+++ b/patterns.go
@@ -4,6 +4,25 @@ import (
 	"strings"
 
 	ma "github.com/multiformats/go-multiaddr"
+	madns "github.com/multiformats/go-multiaddr-dns"
+)
+
+// Define a dns4 format multiaddr
+var DNS4 = Base(madns.P_DNS4)
+
+// Define a dns6 format multiaddr
+var DNS6 = Base(madns.P_DNS6)
+
+var _DNS = Or(
+	Base(madns.P_DNSADDR),
+	DNS4,
+	DNS6,
+)
+
+// Define a dns4 or dns6 format multiaddr
+var DNS = Or(
+	And(_DNS, Base(ma.P_TCP)),
+	_DNS,
 )
 
 // Define IP as either ipv4 or ipv6
@@ -29,6 +48,26 @@ var Reliable = Or(TCP, UTP, QUIC)
 
 // IPFS can run over any reliable underlying transport protocol
 var IPFS = And(Reliable, Base(ma.P_IPFS))
+
+// Define http over TCP or DNS or http over DNS format multiaddr
+var HTTP = Or(
+	And(TCP, Base(ma.P_HTTP)),
+	And(IP, Base(ma.P_HTTP)),
+	And(DNS, Base(ma.P_HTTP)),
+	And(DNS),
+)
+
+// Define https over TCP or DNS or https over DNS format multiaddr
+var HTTPS = Or(
+	And(TCP, Base(ma.P_HTTPS)),
+	And(IP, Base(ma.P_HTTPS)),
+	And(DNS, Base(ma.P_HTTPS)),
+)
+
+// Define p2p-webrtc-direct over HTTP or p2p-webrtc-direct over HTTPS format multiaddr
+var WebRTCDirect = Or(
+	And(HTTP, Base(ma.P_P2P_WEBRTC_DIRECT)),
+	And(HTTPS, Base(ma.P_P2P_WEBRTC_DIRECT)))
 
 const (
 	or  = iota

--- a/patterns_test.go
+++ b/patterns_test.go
@@ -38,6 +38,20 @@ func assertMismatches(t *testing.T, p Pattern, args ...[]string) {
 }
 
 func TestBasicMatching(t *testing.T) {
+	good_dns := []string{
+		"/dnsaddr/ipfs.io",
+		"/dns4/ipfs.io",
+		"/dns4/libp2p.io",
+		"/dns6/protocol.ai",
+		"/dns4/protocol.ai/tcp/80",
+		"/dns6/protocol.ai/tcp/80",
+		"/dnsaddr/protocol.ai/tcp/8",
+	}
+
+	bad_dns := []string{
+		"/ip4/127.0.0.1",
+	}
+
 	good_ip := []string{
 		"/ip4/0.0.0.0",
 		"/ip6/fc00::",
@@ -90,6 +104,11 @@ func TestBasicMatching(t *testing.T) {
 		"/quic",
 	}
 
+	good_webrtcdirect := []string{
+		"/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct",
+		"/ip6/::/tcp/0/http/p2p-webrtc-direct",
+	}
+
 	good_ipfs := []string{
 		"/ip4/1.2.3.4/tcp/1234/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 		"/ip6/::/tcp/1234/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
@@ -105,6 +124,9 @@ func TestBasicMatching(t *testing.T) {
 		"/ip6/::/utp/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 		"/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
 	}
+
+	assertMatches(t, DNS, good_dns)
+	assertMismatches(t, DNS, bad_dns, bad_ip)
 
 	assertMatches(t, IP, good_ip)
 	assertMismatches(t, IP, bad_ip, good_tcp)
@@ -126,6 +148,9 @@ func TestBasicMatching(t *testing.T) {
 
 	assertMatches(t, Unreliable, good_udp)
 	assertMismatches(t, Unreliable, good_ip, good_tcp, good_utp, good_ipfs, good_quic)
+
+	assertMatches(t, WebRTCDirect, good_webrtcdirect)
+	assertMismatches(t, WebRTCDirect, good_ip, good_udp)
 
 	assertMatches(t, IPFS, good_ipfs)
 	assertMismatches(t, IPFS, bad_ipfs, good_ip, good_tcp, good_utp, good_udp, good_quic)


### PR DESCRIPTION
This PR ports the `p2p-webrtc-direct` pattern from `js-mafmt` in preparation of a `go-libp2p-webrtc-direct` transport. It depends on:
- [x] multiformats/go-multiaddr#93
- [x] multiformats/go-multiaddr-dns#11

I'll probably need some help with the dependency management.